### PR TITLE
Fix variable name typo in workflow example

### DIFF
--- a/examples/basic/cmd/workflow/main.go
+++ b/examples/basic/cmd/workflow/main.go
@@ -2,22 +2,22 @@ package main
 
 import (
 	"context"
+	"github.com/targc/spider-go/pkg/spider"
 	"os"
 	"os/signal"
-	"github.com/targc/spider-go/pkg/spider"
 )
 
 func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	worflow, err := spider.InitDefaultWorkflow(ctx)
+	workflow, err := spider.InitDefaultWorkflow(ctx)
 
 	if err != nil {
 		panic(err)
 	}
 
-	storage := worflow.Storage()
+	storage := workflow.Storage()
 
 	workflowID := "wa"
 
@@ -88,7 +88,7 @@ func main() {
 		panic(err)
 	}
 
-	go worflow.Run(ctx)
+	go workflow.Run(ctx)
 
 	nctx, ncancel := signal.NotifyContext(ctx, os.Interrupt)
 	defer ncancel()
@@ -96,5 +96,5 @@ func main() {
 	<-nctx.Done()
 
 	cancel()
-	_ = worflow.Close(ctx)
+	_ = workflow.Close(ctx)
 }


### PR DESCRIPTION
## Summary
- fix workflow variable typo in example worker

## Testing
- `go test ./...` *(fails: no output, interrupted due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68af425590488330aa45284e9a42d134